### PR TITLE
libedit 3.1.20221030

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "libedit" %}
 {% set version = "3.1" %}
-{% set date = "20210910" %}
-{% set sha256 = "6792a6a992050762edcca28ff3318cdb7de37dccf7bc30db59fcd7017eed13c5" %}
+{% set date = "20221030" %}
+{% set sha256 = "f0925a5adf4b1bf116ee19766b7daa766917aec198747943b1c4edf67a4be2bb" %}
 
 package:
   name: {{ name|lower }}
@@ -10,41 +10,41 @@ package:
 source:
   fn: {{ name }}-{{ date }}-{{ version }}.tar.gz
   #url: https://github.com/AnacondaRecipes/libedit-feedstock/releases/download/source/{{ name }}-{{ date }}-{{ version }}.tar.gz
-  url: http://thrysoee.dk/editline/{{ name }}-{{ date }}-{{ version }}.tar.gz
+  url: https://thrysoee.dk/editline/{{ name }}-{{ date }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - 0001-prefer-tinfo-over-curses-and-termcap.patch
 
-
 build:
   number: 0
+  skip: True   # [win]
   run_exports:
     # no info available.  Guessing at x.x.  Change if you know better.
     - {{ pin_subpackage('libedit', max_pin='x.x') }}
-  skip: True   # [win]
 
 requirements:
   build:
     - {{ compiler('c') }}
-    - automake
     - autoconf
+    - automake
     - m4
-    - perl
     - make
     - patch
+    - perl 5.*
+    - pkg-config
   host:
     - ncurses
-
   run:
     - ncurses
 
 test:
   commands:
-    - test -f $PREFIX/lib/libedit.dylib  # [osx]
-    - test -f $PREFIX/lib/libedit.so     # [linux]
+    - test -f ${PREFIX}/lib/pkgconfig/libedit.pc  # [unix]
+    - test -f $PREFIX/lib/libedit.dylib           # [osx]
+    - test -f $PREFIX/lib/libedit.so              # [linux]
 
 about:
-  home: http://thrysoee.dk/editline/
+  home: https://thrysoee.dk/editline/
   license: BSD-2-Clause
   license_family: BSD
   license_file: COPYING
@@ -54,6 +54,8 @@ about:
     (libedit). This Berkeley-style licensed command line editor library provides
     generic line editing, history, and tokenization functions, similar to those
     found in GNU Readline
+  doc_url: https://thrysoee.dk/editline/
+  # dev_url not found.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,9 +39,9 @@ requirements:
 
 test:
   commands:
-    - test -f ${PREFIX}/lib/pkgconfig/libedit.pc  # [unix]
-    - test -f $PREFIX/lib/libedit.dylib           # [osx]
-    - test -f $PREFIX/lib/libedit.so              # [linux]
+    - test -f $PREFIX/lib/pkgconfig/libedit.pc  # [unix]
+    - test -f $PREFIX/lib/libedit.dylib         # [osx]
+    - test -f $PREFIX/lib/libedit.so            # [linux]
 
 about:
   home: https://thrysoee.dk/editline/


### PR DESCRIPTION
**Jira ticket:** [PKG-412](https://anaconda.atlassian.net/browse/PKG-412) (libedit-3.1.20221030)

**The upstream data:**
Requirements & changelog: https://thrysoee.dk/editline/

**_Actions:_**

1. Add `pkg-config`
2. Update `perl` pinning
3. Test `pc` file
4. Fix home & doc urls

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority B | effort: easy | Category: miniconda | subcategory: dependency | pkg_type: library
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64'
 * Latest version: 3.1.20221030
 * Popularity: 
    * 3 months downloads: 6587955.0
    * All time:  20441513 downloads -  libedit  3.1.20191231  Command line editor library provides generic line editing, history, and tokenization functions, similar to those found in GNU Readline.  

</details>

**Other checks:**

<details>

1. - [x] Check the pinnings
5. - [x] Verify that the `build_number` is correct
6.  - [x] Verify the test section
7.  - [x] Verify if the package is `architecture specific`
8.  - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
9.   - [x] license_file: COPYING is present

10.  - [x] license_family BSD is present
11.  - [x] License: BSD-2-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier          |
|:--------------------|
| BSD-2-Clause        |
| BSD-2-Clause-Patent |
| BSD-2-Clause-Views  |
</details>

**Check dependency issues:**

<details>
../aggregate/libedit-feedstock/recipe/meta.yaml
Dependencies: ['ncurses']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  The following packages are missing from the target environment:
  - ncurses

- py3.8:  The following packages are missing from the target environment:
  - ncurses

- py3.9:  The following packages are missing from the target environment:
  - ncurses

- py3.10:  The following packages are missing from the target environment:
  - ncurses

</details>

**Package Build Score: 7**

</details>
